### PR TITLE
feat(game-server): Introduce game server management (GenServers)

### DIFF
--- a/Demo.tscn
+++ b/Demo.tscn
@@ -93,6 +93,7 @@ text = "ping"
 placeholder_text = "Push: Event Name"
 
 [node name="Payload" type="TextEdit" parent="MainContainer/ControlRoom/Push/EventDetailsContainer"]
+custom_minimum_size = Vector2(0, 120)
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3

--- a/modermodemet/lib/modermodemet.ex
+++ b/modermodemet/lib/modermodemet.ex
@@ -2,8 +2,24 @@ defmodule Modermodemet do
   @moduledoc """
   Modermodemet keeps the contexts that define your domain
   and business logic.
-
-  Contexts are also responsible for managing your data, regardless
-  if it comes from the database, an external API or others.
   """
+
+  def create_game() do
+    {:ok, game} = Modermodemet.Game.new()
+
+    {:ok, _game_pid} = Modermodemet.GameSupervisor.start_game(game)
+
+    {:ok, game}
+  end
+
+  def list_games() do
+    games =
+      Modermodemet.GameSupervisor
+      |> Supervisor.which_children()
+      |> Enum.map(fn {_, pid, :worker, [Modermodemet.GameServer]} ->
+        GenServer.call(pid, :get_info)
+      end)
+
+    {:ok, games}
+  end
 end

--- a/modermodemet/lib/modermodemet/application.ex
+++ b/modermodemet/lib/modermodemet/application.ex
@@ -18,7 +18,9 @@ defmodule Modermodemet.Application do
       # Start a worker by calling: Modermodemet.Worker.start_link(arg)
       # {Modermodemet.Worker, arg},
       # Start to serve requests, typically the last entry
-      ModermodemetWeb.Endpoint
+      ModermodemetWeb.Endpoint,
+      Modermodemet.GameRegistry,
+      Modermodemet.GameSupervisor
     ]
 
     # See https://hexdocs.pm/elixir/Supervisor.html

--- a/modermodemet/lib/modermodemet/game.ex
+++ b/modermodemet/lib/modermodemet/game.ex
@@ -1,0 +1,22 @@
+defmodule Modermodemet.Game do
+  defstruct [:id, :created_at, :turn]
+
+  def new() do
+    {:ok,
+     %__MODULE__{
+       id: generate_game_id(),
+       created_at: DateTime.utc_now(),
+       turn: 0
+     }}
+  end
+
+  def advance_turn(%__MODULE__{turn: turn} = game) do
+    # This is where the game logic could go
+    {:ok, %{game | turn: turn + 1}}
+  end
+
+  defp generate_game_id() do
+    :crypto.strong_rand_bytes(5)
+    |> Base.encode32()
+  end
+end

--- a/modermodemet/lib/modermodemet/game_registry.ex
+++ b/modermodemet/lib/modermodemet/game_registry.ex
@@ -1,0 +1,18 @@
+defmodule Modermodemet.GameRegistry do
+  def child_spec([]) do
+    %{
+      id: __MODULE__,
+      start: {Registry, :start_link, [[keys: :unique, name: __MODULE__]]}
+    }
+  end
+
+  @doc """
+  Returns the PID for given game id.
+  """
+  def lookup_pid(game_id) do
+    case Registry.lookup(__MODULE__, game_id) do
+      [] -> :error
+      [{pid, _}] -> {:ok, pid}
+    end
+  end
+end

--- a/modermodemet/lib/modermodemet/game_server.ex
+++ b/modermodemet/lib/modermodemet/game_server.ex
@@ -1,0 +1,43 @@
+defmodule Modermodemet.GameServer do
+  use GenServer
+  require Logger
+
+  defmodule GameInfo do
+    defstruct [:id, :created_at, :turn]
+
+    def from_game(game) do
+      %GameInfo{
+        id: game.id,
+        created_at: game.created_at,
+        turn: game.turn
+      }
+    end
+  end
+
+  def start_link(game) do
+    GenServer.start_link(__MODULE__, game, name: via_tuple(game.id))
+  end
+
+  def init(%Modermodemet.Game{} = game) do
+    Logger.debug("Starting game #{game.id}")
+    {:ok, game}
+  end
+
+  def game_id(game_id) when is_binary(game_id), do: game_id
+
+  def game_id(%Modermodemet.Game{id: id}), do: id
+
+  def get_info(game_id) do
+    GenServer.call(via_tuple(game_id), :get_info)
+  end
+
+  def handle_call(:get_info, _from, game) do
+    {:reply, GameInfo.from_game(game), game}
+  end
+
+  defp via_tuple(pid) when is_pid(pid), do: pid
+
+  defp via_tuple(game_id) do
+    {:via, Registry, {Modermodemet.GameRegistry, game_id}}
+  end
+end

--- a/modermodemet/lib/modermodemet/game_supervisor.ex
+++ b/modermodemet/lib/modermodemet/game_supervisor.ex
@@ -1,0 +1,19 @@
+defmodule Modermodemet.GameSupervisor do
+  use DynamicSupervisor
+
+  def init([]) do
+    DynamicSupervisor.init(strategy: :one_for_one)
+  end
+
+  def start_game(%Modermodemet.Game{} = game) do
+    DynamicSupervisor.start_child(__MODULE__, %{
+      id: game.id,
+      start: {Modermodemet.GameServer, :start_link, [game]},
+      restart: :transient
+    })
+  end
+
+  def start_link([]) do
+    DynamicSupervisor.start_link(__MODULE__, [], name: __MODULE__)
+  end
+end

--- a/modermodemet/test/modermodemet/game_test.exs
+++ b/modermodemet/test/modermodemet/game_test.exs
@@ -1,0 +1,24 @@
+defmodule Modermodemet.Game.Test do
+  use ExUnit.Case, async: false
+  alias Modermodemet, as: GameManagement
+
+  test "create_game/0 creates a game and returns it" do
+    assert {:ok, %GameManagement.Game{} = game} = GameManagement.create_game()
+
+    # Assert the game's default fields
+    assert game.turn == 0
+  end
+
+  test "list_games/0 returns a list of games" do
+    # Start by ensuring no games are running
+    assert {:ok, []} = GameManagement.list_games()
+
+    # Create a game
+    {:ok, _game} = GameManagement.create_game()
+
+    # Now list_games should return at least one game
+    assert {:ok, games} = GameManagement.list_games()
+    assert length(games) > 0
+  end
+end
+


### PR DESCRIPTION
- Use a [dynamic supervisor](https://hexdocs.pm/elixir/1.13/DynamicSupervisor.html#content) to be able to spawn [GenServers](https://hexdocs.pm/elixir/1.13/GenServer.html) for game servers. Isolate failures with strategy :one_for_one
- Keep track of them in a registry so we can fetch a Game server by either PID or game id.
- Simple start at a `Game` struct, that just holds id, createdAt and a turn property TBD